### PR TITLE
Add infrastructure to handle error messaging between storybook and web

### DIFF
--- a/src/addons/constants.js
+++ b/src/addons/constants.js
@@ -4,6 +4,7 @@ const STORY_SELECTED_EVENT = `${DSM_ADDON_NAME}/on_story_selected`;
 const HTML_SAMPLE_CODE_CHANGED_EVENT = `${DSM_ADDON_NAME}/on_html_sample_code_changed`;
 const INIT_DSM_REGISTERED_EVENT = `${DSM_ADDON_NAME}/on_init_dsm_registered`;
 const INIT_DSM_EVENT = `${DSM_ADDON_NAME}/on_init_dsm`;
+const DSM_STORYBOOK_START_EVENT = `${DSM_ADDON_NAME}/dsm_storybook_start_event`;
 const INJECTED_SOURCE_PLACEHOLDER = '__DSM_INJECTED_SOURCE__';
 const KNOBS_SET_EVENT = 'addon:knobs:setKnobs';
 const KNOBS_SET_EVENT_V5_1 = 'storybookjs/knobs/set';
@@ -16,6 +17,7 @@ const FRAMEWORKS = { html: 'html', react: 'react', angular: 'angular', vue: 'vue
 module.exports = {
   DSM_ADDON_NAME,
   DSM_INFO_OBJECT_KEY,
+  DSM_STORYBOOK_START_EVENT,
   STORY_SELECTED_EVENT,
   HTML_SAMPLE_CODE_CHANGED_EVENT,
   INIT_DSM_REGISTERED_EVENT,

--- a/src/addons/index.js
+++ b/src/addons/index.js
@@ -5,7 +5,7 @@ import withDsm from './with-dsm';
 import getDsmOptions from './dsm-options';
 import { get } from 'lodash';
 import { setConfiguration, isInDsmContext } from '../services/configuration';
-import { INIT_DSM_EVENT, INIT_DSM_REGISTERED_EVENT } from './constants';
+import { INIT_DSM_EVENT, INIT_DSM_REGISTERED_EVENT, DSM_STORYBOOK_START_EVENT } from './constants';
 import { getByVersion, resolvers } from './versions';
 
 /**
@@ -46,6 +46,10 @@ const initDsm = (params) => {
 
   // Inform the register code that we are listening to the INIT_DSM_EVENT
   channel.emit(`${INIT_DSM_REGISTERED_EVENT}`);
+
+  // Inform DSM that we have started configuring the addon. This triggers an error
+  // timer in DSM where we wait for storybook content to load.
+  channel.emit(`${DSM_STORYBOOK_START_EVENT}`);
 };
 
 /**

--- a/src/addons/register.js
+++ b/src/addons/register.js
@@ -16,7 +16,8 @@ import {
   HTML_SAMPLE_CODE_CHANGED_EVENT,
   KNOBS_SET_EVENT as DSM_KNOBS_SET_EVENT,
   INIT_DSM_REGISTERED_EVENT,
-  INIT_DSM_EVENT
+  INIT_DSM_EVENT,
+  DSM_STORYBOOK_START_EVENT
 } from './constants';
 
 export function registerDsm(envVariable) {
@@ -39,6 +40,12 @@ export function registerDsm(envVariable) {
 
     if (isInDsmContext()) {
       injectCss();
+
+      channel.on(`${DSM_STORYBOOK_START_EVENT}`, () => {
+        notifyDsm({
+          eventName: DSM_STORYBOOK_START_EVENT
+        });
+      });
 
       channel.on(STORY_SELECTED_EVENT, (data) => {
         notifyDsm(data);

--- a/src/services/notify-dsm.js
+++ b/src/services/notify-dsm.js
@@ -1,4 +1,4 @@
-export default function(message) {
+export default function notifyDsm(message) {
   // window here is the manager windows
   window.parent.postMessage(message, '*');
 }


### PR DESCRIPTION
We now better handle errors that occur within dsm-storybook and propagate errors to the web to show a fallback UI.