### PR TITLE
Fix react-docgen parsing errors with TypeScript and custom babel configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -597,6 +597,11 @@
             }
          }
       },
+      "@babel/helper-validator-identifier": {
+         "version": "7.9.5",
+         "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+         "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+      },
       "@babel/helper-wrap-function": {
          "version": "7.7.0",
          "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.0.tgz",
@@ -643,6 +648,7 @@
          "version": "7.7.0",
          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.0.tgz",
          "integrity": "sha512-VnNwL4YOhbejHb7x/b5F39Zdg5vIQpUUNzJwx0ww1EcVRt41bbGRZWhAURrfY32T5zTT3qwNOQFWpn+P0i0a2g==",
+         "dev": true,
          "requires": {
             "@babel/template": "^7.7.0",
             "@babel/traverse": "^7.7.0",
@@ -653,6 +659,7 @@
                "version": "7.7.2",
                "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
                "integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
+               "dev": true,
                "requires": {
                   "@babel/code-frame": "^7.5.5",
                   "@babel/generator": "^7.7.2",
@@ -669,6 +676,7 @@
                "version": "7.7.2",
                "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
                "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+               "dev": true,
                "requires": {
                   "esutils": "^2.0.2",
                   "lodash": "^4.17.13",
@@ -1233,11 +1241,11 @@
          }
       },
       "@babel/runtime": {
-         "version": "7.7.2",
-         "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
-         "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
+         "version": "7.9.2",
+         "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+         "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
          "requires": {
-            "regenerator-runtime": "^0.13.2"
+            "regenerator-runtime": "^0.13.4"
          }
       },
       "@babel/template": {
@@ -2210,14 +2218,6 @@
          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
          "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
          "dev": true
-      },
-      "async": {
-         "version": "2.6.3",
-         "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-         "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-         "requires": {
-            "lodash": "^4.17.14"
-         }
       },
       "async-each": {
          "version": "1.0.3",
@@ -5280,6 +5280,11 @@
          "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
          "dev": true
       },
+      "gensync": {
+         "version": "1.0.0-beta.1",
+         "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+         "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
+      },
       "get-caller-file": {
          "version": "2.0.5",
          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -6972,6 +6977,7 @@
          "version": "2.1.1",
          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
          "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+         "dev": true,
          "requires": {
             "minimist": "^1.2.0"
          }
@@ -7352,6 +7358,11 @@
          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
       },
+      "min-indent": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
+         "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY="
+      },
       "minimalistic-assert": {
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -7375,7 +7386,8 @@
       "minimist": {
          "version": "1.2.0",
          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-         "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+         "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+         "dev": true
       },
       "mississippi": {
          "version": "3.0.0",
@@ -7517,8 +7529,7 @@
       "neo-async": {
          "version": "2.6.1",
          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-         "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
-         "dev": true
+         "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
       },
       "nice-try": {
          "version": "1.0.5",
@@ -8847,66 +8858,224 @@
          }
       },
       "react-docgen": {
-         "version": "5.0.0-beta.1",
-         "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-5.0.0-beta.1.tgz",
-         "integrity": "sha512-CbbHF5jXrgyXuP3gQcN1zG4YpNj5QQuxTsEhKH3UXQN01V4cho/eL926ya6ecCWryUtlK97QGRxtK48KbCtXEQ==",
+         "version": "5.3.0",
+         "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-5.3.0.tgz",
+         "integrity": "sha512-hUrv69k6nxazOuOmdGeOpC/ldiKy7Qj/UFpxaQi0eDMrUFUTIPGtY5HJu7BggSmiyAMfREaESbtBL9UzdQ+hyg==",
          "requires": {
-            "@babel/core": "^7.4.4",
-            "@babel/runtime": "^7.0.0",
-            "ast-types": "^0.12.4",
-            "async": "^2.1.4",
+            "@babel/core": "^7.7.5",
+            "@babel/runtime": "^7.7.6",
+            "ast-types": "^0.13.2",
             "commander": "^2.19.0",
             "doctrine": "^3.0.0",
+            "neo-async": "^2.6.1",
             "node-dir": "^0.1.10",
-            "strip-indent": "^2.0.0"
+            "strip-indent": "^3.0.0"
          },
          "dependencies": {
-            "@babel/core": {
-               "version": "7.7.2",
-               "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.2.tgz",
-               "integrity": "sha512-eeD7VEZKfhK1KUXGiyPFettgF3m513f8FoBSWiQ1xTvl1RAopLs42Wp9+Ze911I6H0N9lNqJMDgoZT7gHsipeQ==",
+            "@babel/code-frame": {
+               "version": "7.8.3",
+               "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+               "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
                "requires": {
-                  "@babel/code-frame": "^7.5.5",
-                  "@babel/generator": "^7.7.2",
-                  "@babel/helpers": "^7.7.0",
-                  "@babel/parser": "^7.7.2",
-                  "@babel/template": "^7.7.0",
-                  "@babel/traverse": "^7.7.2",
-                  "@babel/types": "^7.7.2",
+                  "@babel/highlight": "^7.8.3"
+               }
+            },
+            "@babel/core": {
+               "version": "7.9.0",
+               "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+               "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+               "requires": {
+                  "@babel/code-frame": "^7.8.3",
+                  "@babel/generator": "^7.9.0",
+                  "@babel/helper-module-transforms": "^7.9.0",
+                  "@babel/helpers": "^7.9.0",
+                  "@babel/parser": "^7.9.0",
+                  "@babel/template": "^7.8.6",
+                  "@babel/traverse": "^7.9.0",
+                  "@babel/types": "^7.9.0",
                   "convert-source-map": "^1.7.0",
                   "debug": "^4.1.0",
-                  "json5": "^2.1.0",
+                  "gensync": "^1.0.0-beta.1",
+                  "json5": "^2.1.2",
                   "lodash": "^4.17.13",
                   "resolve": "^1.3.2",
                   "semver": "^5.4.1",
                   "source-map": "^0.5.0"
                }
             },
-            "@babel/traverse": {
-               "version": "7.7.2",
-               "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
-               "integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
+            "@babel/generator": {
+               "version": "7.9.5",
+               "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
+               "integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
                "requires": {
-                  "@babel/code-frame": "^7.5.5",
-                  "@babel/generator": "^7.7.2",
-                  "@babel/helper-function-name": "^7.7.0",
-                  "@babel/helper-split-export-declaration": "^7.7.0",
-                  "@babel/parser": "^7.7.2",
-                  "@babel/types": "^7.7.2",
+                  "@babel/types": "^7.9.5",
+                  "jsesc": "^2.5.1",
+                  "lodash": "^4.17.13",
+                  "source-map": "^0.5.0"
+               }
+            },
+            "@babel/helper-function-name": {
+               "version": "7.9.5",
+               "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+               "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+               "requires": {
+                  "@babel/helper-get-function-arity": "^7.8.3",
+                  "@babel/template": "^7.8.3",
+                  "@babel/types": "^7.9.5"
+               }
+            },
+            "@babel/helper-get-function-arity": {
+               "version": "7.8.3",
+               "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+               "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+               "requires": {
+                  "@babel/types": "^7.8.3"
+               }
+            },
+            "@babel/helper-member-expression-to-functions": {
+               "version": "7.8.3",
+               "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+               "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+               "requires": {
+                  "@babel/types": "^7.8.3"
+               }
+            },
+            "@babel/helper-module-imports": {
+               "version": "7.8.3",
+               "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+               "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+               "requires": {
+                  "@babel/types": "^7.8.3"
+               }
+            },
+            "@babel/helper-module-transforms": {
+               "version": "7.9.0",
+               "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
+               "integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+               "requires": {
+                  "@babel/helper-module-imports": "^7.8.3",
+                  "@babel/helper-replace-supers": "^7.8.6",
+                  "@babel/helper-simple-access": "^7.8.3",
+                  "@babel/helper-split-export-declaration": "^7.8.3",
+                  "@babel/template": "^7.8.6",
+                  "@babel/types": "^7.9.0",
+                  "lodash": "^4.17.13"
+               }
+            },
+            "@babel/helper-optimise-call-expression": {
+               "version": "7.8.3",
+               "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+               "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+               "requires": {
+                  "@babel/types": "^7.8.3"
+               }
+            },
+            "@babel/helper-replace-supers": {
+               "version": "7.8.6",
+               "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
+               "integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+               "requires": {
+                  "@babel/helper-member-expression-to-functions": "^7.8.3",
+                  "@babel/helper-optimise-call-expression": "^7.8.3",
+                  "@babel/traverse": "^7.8.6",
+                  "@babel/types": "^7.8.6"
+               }
+            },
+            "@babel/helper-simple-access": {
+               "version": "7.8.3",
+               "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+               "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+               "requires": {
+                  "@babel/template": "^7.8.3",
+                  "@babel/types": "^7.8.3"
+               }
+            },
+            "@babel/helper-split-export-declaration": {
+               "version": "7.8.3",
+               "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+               "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+               "requires": {
+                  "@babel/types": "^7.8.3"
+               }
+            },
+            "@babel/helpers": {
+               "version": "7.9.2",
+               "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
+               "integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+               "requires": {
+                  "@babel/template": "^7.8.3",
+                  "@babel/traverse": "^7.9.0",
+                  "@babel/types": "^7.9.0"
+               }
+            },
+            "@babel/highlight": {
+               "version": "7.9.0",
+               "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+               "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+               "requires": {
+                  "@babel/helper-validator-identifier": "^7.9.0",
+                  "chalk": "^2.0.0",
+                  "js-tokens": "^4.0.0"
+               }
+            },
+            "@babel/parser": {
+               "version": "7.9.4",
+               "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+               "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
+            },
+            "@babel/template": {
+               "version": "7.8.6",
+               "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+               "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+               "requires": {
+                  "@babel/code-frame": "^7.8.3",
+                  "@babel/parser": "^7.8.6",
+                  "@babel/types": "^7.8.6"
+               }
+            },
+            "@babel/traverse": {
+               "version": "7.9.5",
+               "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
+               "integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
+               "requires": {
+                  "@babel/code-frame": "^7.8.3",
+                  "@babel/generator": "^7.9.5",
+                  "@babel/helper-function-name": "^7.9.5",
+                  "@babel/helper-split-export-declaration": "^7.8.3",
+                  "@babel/parser": "^7.9.0",
+                  "@babel/types": "^7.9.5",
                   "debug": "^4.1.0",
                   "globals": "^11.1.0",
                   "lodash": "^4.17.13"
                }
             },
             "@babel/types": {
-               "version": "7.7.2",
-               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
-               "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+               "version": "7.9.5",
+               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+               "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
                "requires": {
-                  "esutils": "^2.0.2",
+                  "@babel/helper-validator-identifier": "^7.9.5",
                   "lodash": "^4.17.13",
                   "to-fast-properties": "^2.0.0"
                }
+            },
+            "ast-types": {
+               "version": "0.13.3",
+               "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.3.tgz",
+               "integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA=="
+            },
+            "json5": {
+               "version": "2.1.3",
+               "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+               "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+               "requires": {
+                  "minimist": "^1.2.5"
+               }
+            },
+            "minimist": {
+               "version": "1.2.5",
+               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+               "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
             },
             "semver": {
                "version": "5.7.1",
@@ -9029,9 +9198,9 @@
          }
       },
       "regenerator-runtime": {
-         "version": "0.13.3",
-         "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-         "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+         "version": "0.13.5",
+         "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+         "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
       },
       "regenerator-transform": {
          "version": "0.14.1",
@@ -10042,9 +10211,12 @@
          "dev": true
       },
       "strip-indent": {
-         "version": "2.0.0",
-         "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-         "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+         "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+         "requires": {
+            "min-indent": "^1.0.0"
+         }
       },
       "strip-json-comments": {
          "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       "prettier": "1.19.1",
       "prism-react-renderer": "1.0.2",
       "prismjs": "1.15.0",
-      "react-docgen": "5.0.0-beta.1",
+      "react-docgen": "5.3.0",
       "read-pkg": "4.0.1",
       "read-pkg-up": "4.0.0",
       "request-promise": "4.2.4",

--- a/src/metadata/framework-analyzers/react/docgen-parser.js
+++ b/src/metadata/framework-analyzers/react/docgen-parser.js
@@ -1,0 +1,50 @@
+import fs from 'fs-extra';
+import { parse as babelParse } from 'react-docgen';
+import { FileType } from '../../utils/parser-constants';
+import getParserType from '../../utils/get-parser-type';
+
+export function parse(componentFilePath) {
+  const src = fs.readFileSync(componentFilePath, 'utf8');
+  const parserType = getParserType(componentFilePath);
+  const parserOptions = getDefaultParserOptions(parserType);
+
+  return babelParse(src, null, null, { filename: componentFilePath, parserOptions: parserOptions });
+}
+
+// Manually add all plugins to ensure we are able to parse user code
+// regardless of their babel tooling. Based on `react-docgen babelParser`:
+// https://github.com/reactjs/react-docgen/blob/master/src/babelParser.js
+function getDefaultParserOptions(type) {
+  return {
+    plugins: [
+      'jsx',
+      getLanguagePlugin(type), // load appropriate plugin based on language (JS, TS)
+      'asyncGenerators',
+      'bigInt',
+      'classProperties',
+      'classPrivateProperties',
+      'classPrivateMethods',
+      ['decorators', { decoratorsBeforeExport: false }],
+      'doExpressions',
+      'dynamicImport',
+      'exportDefaultFrom',
+      'exportNamespaceFrom',
+      'functionBind',
+      'functionSent',
+      'importMeta',
+      'logicalAssignment',
+      'nullishCoalescingOperator',
+      'numericSeparator',
+      'objectRestSpread',
+      'optionalCatchBinding',
+      'optionalChaining',
+      ['pipelineOperator', { proposal: 'minimal' }],
+      'throwExpressions',
+      'topLevelAwait'
+    ]
+  };
+}
+
+function getLanguagePlugin(type) {
+  return type === FileType.TYPESCRIPT ? FileType.TYPESCRIPT : '';
+}

--- a/src/metadata/framework-analyzers/react/get-docgen-info.js
+++ b/src/metadata/framework-analyzers/react/get-docgen-info.js
@@ -1,0 +1,5 @@
+import { parse } from './docgen-parser';
+
+export function getDocgenInfo(componentFilePath) {
+  return parse(componentFilePath);
+}

--- a/src/metadata/framework-analyzers/react/prop-extractor.js
+++ b/src/metadata/framework-analyzers/react/prop-extractor.js
@@ -1,6 +1,5 @@
-const fs = require('fs-extra');
-const reactDocGen = require('react-docgen');
 const isUndefined = require('lodash/isUndefined');
+const { getDocgenInfo } = require('./get-docgen-info');
 
 /**
  * Attempt to extract prop definitions and add them as a "props" property on "dsmInfo"
@@ -10,9 +9,7 @@ function extract(componentFilePath) {
     return;
   }
 
-  const src = fs.readFileSync(componentFilePath, 'utf8');
-  const docgenInfo = reactDocGen.parse(src, null, null, { filename: componentFilePath });
-
+  const docgenInfo = getDocgenInfo(componentFilePath);
   return normalizeDocgenInfo(docgenInfo);
 }
 

--- a/test/frameworks/react/data/Button.tsx
+++ b/test/frameworks/react/data/Button.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+// @ts-ignore // we don't install TS-related dependencies in dsm-storybook
+import { chevronRightIcon } from './icons';
+// @ts-ignore
+import SVGInline from 'react-svg-inline';
+
+import './_button.scss';
+
+type ButtonProps = {
+  /**
+   * Adds an icon to the button
+   */
+  icon: 'chevron-right' | 'another-icon';
+  /**
+   * The content of the Button
+   * */
+  children: React.ReactNode;
+  /**
+   * Disable state of the button
+   */
+  disabled: boolean;
+  /**
+   * The function to be called when the button is clicked
+   */
+  onClick: (e: React.MouseEvent) => void;
+  anotherProp: 1 | 2 | 3;
+};
+
+/**
+ * Button description
+ * */
+const Button = ({ onClick, icon, children, disabled = false, anotherProp = 2 }: ButtonProps) => {
+  return (
+    <button
+      onClick={!disabled && onClick}
+      className={`c-button ${icon && 'c-button__with-icon'} ${disabled && 'c-button__disabled'}`}
+    >
+      <div className="c-button__content">{children}</div>
+      {icon && (
+        <div className="c-button__icon">
+          <SVGInline svg={chevronRightIcon} />
+        </div>
+      )}
+    </button>
+  );
+};
+
+export default Button;

--- a/test/frameworks/react/react-prop-extractor.test.js
+++ b/test/frameworks/react/react-prop-extractor.test.js
@@ -2,13 +2,13 @@ const { assert } = require('chai');
 const path = require('path');
 const propExtractor = require('../../../src/metadata/framework-analyzers/react/prop-extractor');
 
-let componentFilePath = undefined;
+describe('react - prop extractor on JavaScript files', function() {
+  let componentFilePath = undefined;
 
-beforeAll(function() {
-  componentFilePath = path.resolve(__dirname, './data/Button.jsx');
-});
+  beforeAll(function() {
+    componentFilePath = path.resolve(__dirname, './data/Button.jsx');
+  });
 
-describe('react - prop extractor', function() {
   it('extracts component data', function() {
     const docgenInfo = propExtractor.extract(componentFilePath);
     assert.equal(docgenInfo.description, 'Button description');
@@ -44,8 +44,56 @@ describe('react - prop extractor', function() {
     assert.equal(docgenInfo.props.anotherProp.defaultValue.value, 2);
   });
 
-  it('handles number type', function() {
+  it('handles function type', function() {
     const docgenInfo = propExtractor.extract(componentFilePath);
     assert.equal(docgenInfo.props.onClick.type.name, 'func');
+  });
+});
+
+describe('react - prop extractor on TypeScript files', function() {
+  let componentFilePath = undefined;
+
+  beforeAll(function() {
+    componentFilePath = path.resolve(__dirname, './data/Button.tsx');
+  });
+
+  it('extracts component data', function() {
+    const docgenInfo = propExtractor.extract(componentFilePath);
+    assert.equal(docgenInfo.description, 'Button description');
+    assert.equal(docgenInfo.displayName, 'Button');
+  });
+
+  it('extracts prop description', function() {
+    const docgenInfo = propExtractor.extract(componentFilePath);
+    assert.equal(docgenInfo.props.disabled.description, 'Disable state of the button');
+  });
+
+  it('extracts default value', function() {
+    const docgenInfo = propExtractor.extract(componentFilePath);
+    assert.equal(docgenInfo.props.disabled.defaultValue.value, 'false');
+  });
+
+  it('props without default value do not have default value in the docgen', function() {
+    const docgenInfo = propExtractor.extract(componentFilePath);
+    assert.equal(docgenInfo.props.icon.defaultValue, undefined);
+  });
+
+  it('handles multiple string options', function() {
+    const docgenInfo = propExtractor.extract(componentFilePath);
+    assert.equal(docgenInfo.props.icon.type.name, 'union');
+    assert.equal(docgenInfo.props.icon.type.value[0].value, "'chevron-right'");
+    assert.equal(docgenInfo.props.icon.type.value[1].value, "'another-icon'");
+  });
+
+  it('handles multiple number options', function() {
+    const docgenInfo = propExtractor.extract(componentFilePath);
+    assert.equal(docgenInfo.props.anotherProp.type.name, 'union');
+    assert.equal(docgenInfo.props.anotherProp.type.value[2].value, 3);
+    assert.equal(docgenInfo.props.anotherProp.defaultValue.value, 2);
+  });
+
+  it('handles function type', function() {
+    const docgenInfo = propExtractor.extract(componentFilePath);
+    assert.equal(docgenInfo.props.onClick.type.name, 'signature');
   });
 });


### PR DESCRIPTION
react-docgen would sometimes incorrectly parse a TypeScript file if a user has a custom babel configuration file.